### PR TITLE
fix: tag code block as text to prevent rubocop-md lint

### DIFF
--- a/.claude/commands/create-skill.md
+++ b/.claude/commands/create-skill.md
@@ -140,7 +140,7 @@ Which is your intent?
 
 Store the clarified purpose for use in later phases:
 
-```
+```text
 SKILL_PURPOSE="Developing custom GitHub Actions (JS/TS, Docker, Composite)"
 SKILL_NOT_ABOUT="Writing workflow YAML files, managing Actions settings"
 ```


### PR DESCRIPTION
## Summary

- `brew style` uses `rubocop-md` which auto-detects untagged code blocks as Ruby
- The `SKILL_PURPOSE`/`SKILL_NOT_ABOUT` assignments in `create-skill.md` look like Ruby constants, triggering `Style/MutableConstant`
- Adding `text` language tag to the code block prevents `rubocop-md` from parsing it

Fixes the `brew test-bot` failures on PR #37 (and any other PR).

Note: PR #38's approach (`.rubocop.yml` excludes) didn't work because `brew style` passes `--config` pointing to Homebrew's own config, ignoring the tap's `.rubocop.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)