### PR TITLE
fix(ci): use GitHub App token for bump-formulas workflow

### DIFF
--- a/.github/workflows/bump-formulas.yml
+++ b/.github/workflows/bump-formulas.yml
@@ -25,19 +25,37 @@ permissions:
   contents: read
 
 jobs:
-  bump-formulas:
+  generate-token:
+    name: Generate App Token
     runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
     steps:
       - name: Load secrets from 1Password
+        id: op-secrets
         uses: 1password/load-secrets-action@v3
+        with:
+          export-env: false
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SVC_ACCT_TOKEN }}
-          HOMEBREW_PAT: op://gh-homebrew-tap/gh-homebrew-tap/token
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          X_REPO_AUTH_APP_ID: op://gh-shared/xauth/app/id
+          X_REPO_AUTH_PRIVATE_KEY: op://gh-shared/xauth/app/private-key.pem
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
+          private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
+
+  bump-formulas:
+    needs: [generate-token]
+    runs-on: ubuntu-latest
+    steps:
       - name: Bump Homebrew formulas
         uses: dawidd6/action-homebrew-bump-formula@v7
         with:
-          token: ${{ env.HOMEBREW_PAT }}
+          token: ${{ needs.generate-token.outputs.token }}
           tap: aRustyDev/tap
           formula: ${{ inputs.formula }}
           livecheck: true


### PR DESCRIPTION
## Summary

- Replace PAT-based auth (via 1Password `op://gh-homebrew-tap/...`) with GitHub App token pattern
- Matches the pattern used in `helm-charts` repo (`op://gh-shared/xauth/app/*`)
- App tokens are short-lived, automatically scoped, and don't depend on personal accounts

## Note

This uses the `OP_SERVICE_ACCOUNT_TOKEN` secret name (matching helm-charts). Verify this secret exists in the repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)