### PR TITLE
fix(ci): collapse bump-formulas into single job

### DIFF
--- a/.github/workflows/bump-formulas.yml
+++ b/.github/workflows/bump-formulas.yml
@@ -25,11 +25,8 @@ permissions:
   contents: read
 
 jobs:
-  generate-token:
-    name: Generate App Token
+  bump-formulas:
     runs-on: ubuntu-latest
-    outputs:
-      token: ${{ steps.app-token.outputs.token }}
     steps:
       - name: Load secrets from 1Password
         id: op-secrets
@@ -48,14 +45,10 @@ jobs:
           app-id: ${{ steps.op-secrets.outputs.X_REPO_AUTH_APP_ID }}
           private-key: ${{ steps.op-secrets.outputs.X_REPO_AUTH_PRIVATE_KEY }}
 
-  bump-formulas:
-    needs: [generate-token]
-    runs-on: ubuntu-latest
-    steps:
       - name: Bump Homebrew formulas
         uses: dawidd6/action-homebrew-bump-formula@v7
         with:
-          token: ${{ needs.generate-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token }}
           tap: aRustyDev/tap
           formula: ${{ inputs.formula }}
           livecheck: true


### PR DESCRIPTION
## Summary

The split-job pattern from PR #40 fails for two reasons:
1. **GitHub Actions refuses to pass secrets as job outputs**: `Skip output 'token' since it may contain secret.`
2. **Token revocation**: `create-github-app-token` revokes the token in post-job cleanup before the next job starts

Fix: move token generation and bump into a single job so the token stays alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)