### PR TITLE
fix(ci): set git identity for app token in bump-formulas

### DIFF
--- a/.github/workflows/bump-formulas.yml
+++ b/.github/workflows/bump-formulas.yml
@@ -54,3 +54,5 @@ jobs:
           livecheck: true
           force: ${{ inputs.force || false }}
           no_fork: true
+          user-name: "x-repo-auth[bot]"
+          user-email: "2608951+x-repo-auth[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- `dawidd6/action-homebrew-bump-formula` calls `/user` API to resolve git name/email
- GitHub App tokens can't access `/user` → `Resource not accessible by integration`
- Setting `user-name` and `user-email` inputs skips the `/user` call (see [main.rb:64-66](https://github.com/dawidd6/action-homebrew-bump-formula/blob/v7/main.rb#L64))

🤖 Generated with [Claude Code](https://claude.com/claude-code)